### PR TITLE
Replace metasearch with Ransack and address a few mass assignment issues

### DIFF
--- a/app/controllers/spree/admin/product_groups_controller.rb
+++ b/app/controllers/spree/admin/product_groups_controller.rb
@@ -20,10 +20,10 @@ module Spree
         end
 
         def collection
-          params[:search] ||= {}
-          params[:search][:meta_sort] ||= "name.asc"
-          @search = super.metasearch(params[:search])
-          @collection = @search.relation.page(params[:page]).per(Spree::Config[:admin_pgroup_per_page])
+          params[:q] ||= {}
+          params[:q][:sort] ||= "name.asc"
+          @search = super.search(params[:q])
+          @collection = @search.result(:distinct => true).page(params[:page]).per(Spree::Config[:admin_pgroup_per_page])
         end
     
       private

--- a/app/models/spree/product_group.rb
+++ b/app/models/spree/product_group.rb
@@ -42,6 +42,8 @@ module Spree
 
     make_permalink
 
+    attr_accessible :name, :permalink, :product_scope, :order_scope
+
     # Testing utility: creates new *ProductGroup* from search permalink url.
     # Follows conventions for accessing PGs from URLs, as decoded in routes
     def self.from_url(url)

--- a/app/models/spree/product_scope.rb
+++ b/app/models/spree/product_scope.rb
@@ -15,6 +15,8 @@ module Spree
 
     extend ::Spree::Scopes::Dynamic
 
+    attr_accessible :name, :arguments
+
     # Get all products with this scope
     def products
       if Product.respond_to?(name)


### PR DESCRIPTION
With the Spree RC release of 1.1.0, they replaced metasearch with ransack. This required a few controller changes. Also, Rails 3.2.3 introduced some security changes that requires indicating which attributes can be updated via attr_accessible.

This pull request attempts to address those changes.
