### PR TITLE
Products no longer have an images association, removing it from eager lo...

### DIFF
--- a/lib/spree/core/search/product_group_base.rb
+++ b/lib/spree/core/search/product_group_base.rb
@@ -14,7 +14,7 @@ module Spree
           @products_scope = @product_group.apply_on(base_scope)
           curr_page = manage_pagination && keywords ? 1 : page
 
-          @products = @products_scope.includes([:images, :master]).page(curr_page).per(per_page)
+          @products = @products_scope.includes(:master).page(curr_page).per(per_page)
         end
 
         def method_missing(name)


### PR DESCRIPTION
Including the products extension gives the following error when loading the products index or a product group:

```
Association named 'images' was not found; perhaps you misspelled it?
```

The images association no longer exists on products as of 1.1. The product groups extension was trying to eagerly load images on products. I've removed this and it seems to have fixed the problem.
