### PR TITLE
Replace metasearch with ransack

### DIFF
--- a/app/models/spree/product_scope.rb
+++ b/app/models/spree/product_scope.rb
@@ -48,7 +48,7 @@ module Spree
                         Product.send(self.name.intern, *array)
                     end
       else
-        relation2 = Product.metasearch({ self.name.intern => array.join("") }).relation
+        relation2 = Product.ransack({ self.name.intern => array.join("") }).result
       end
       unless another_scope.class == ActiveRecord::Relation
         another_scope = another_scope.send(:relation)


### PR DESCRIPTION
There was still a metasearch call in the code, this is not working anymore because it was replaced by ransack.
