### PR TITLE
Chain scopes instead of merging in Spree::ProductScope#apply_on.

### DIFF
--- a/app/models/spree/product_scope.rb
+++ b/app/models/spree/product_scope.rb
@@ -32,28 +32,27 @@ module Spree
     # Applies product scope on Spree::Product model or another named scope
     def apply_on(another_scope)
       array = Array.wrap(self.arguments)
-      if Product.respond_to?(self.name.intern)
-        relation2 = if (array.blank? || array.size < 2)
-                      if Product.method(self.name.intern).arity == 0
-                        Product.send(self.name.intern)
-                      else
-                        # Since IDs are comma seperated in the first argument we need to correctly pass the ID array to the with_ids scope.
-                        if self.name == 'with_ids'
-                          Product.with_ids(array.first.split(','))
-                        else
-                          Product.send(self.name.intern, array.try(:first))
-                        end
-                      end
-                    else
-                        Product.send(self.name.intern, *array)
-                    end
-      else
-        relation2 = Product.ransack({ self.name.intern => array.join("") }).result
-      end
       unless another_scope.class == ActiveRecord::Relation
         another_scope = another_scope.send(:relation)
       end
-      another_scope.merge(relation2)
+      if Product.respond_to?(self.name.intern)
+        if (array.blank? || array.size < 2)
+          if Product.method(self.name.intern).arity == 0
+            another_scope.send(self.name.intern)
+          else
+            # Since IDs are comma seperated in the first argument we need to correctly pass the ID array to the with_ids scope.
+            if self.name == 'with_ids'
+              another_scope.with_ids(array.first.split(','))
+            else
+              another_scope.send(self.name.intern, array.try(:first))
+            end
+          end
+        else
+          another_scope.send(self.name.intern, *array)
+        end
+      else
+        another_scope.ransack({ self.name.intern => array.join("") }).result
+      end
     end
 
     # checks validity of the named scope (if its safe and can be applied on Spree::Product)

--- a/app/models/spree/promotion/rules/product_decorator.rb
+++ b/app/models/spree/promotion/rules/product_decorator.rb
@@ -1,4 +1,4 @@
-unless defined?(Spree::Promotion)
+if defined?(Spree::Promotion)
   module Spree
     class Promotion < Spree::Activator
       module Rules

--- a/app/models/spree/promotion/rules/product_decorator.rb
+++ b/app/models/spree/promotion/rules/product_decorator.rb
@@ -1,20 +1,22 @@
-module Spree
-  class Promotion < Spree::Activator
-    module Rules
-      Product.class_eval do
-        belongs_to :product_group
-        attr_accessible :products_source, :product_group_id
+unless defined?(Spree::Promotion)
+  module Spree
+    class Promotion < Spree::Activator
+      module Rules
+        Product.class_eval do
+          belongs_to :product_group
+          attr_accessible :products_source, :product_group_id
 
-        def eligible_products
-          product_group ? product_group.products : products
-        end
-
-        def products_source=(source)
-          if source.to_s == 'manual'
-            self.product_group_id = nil
+          def eligible_products
+            product_group ? product_group.products : products
           end
-        end
 
+          def products_source=(source)
+            if source.to_s == 'manual'
+              self.product_group_id = nil
+            end
+          end
+
+        end
       end
     end
   end

--- a/app/models/spree/promotion/rules/product_decorator.rb
+++ b/app/models/spree/promotion/rules/product_decorator.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Promotion
+  class Promotion < Spree::Activator
     module Rules
       Product.class_eval do
         belongs_to :product_group

--- a/spec/models/product_scope_spec.rb
+++ b/spec/models/product_scope_spec.rb
@@ -46,6 +46,13 @@ describe Spree::ProductScope do
         subject.arguments = ["#{product_1.id},#{product_2.id}"]
         subject.products.to_a.should eql([product_1, product_2])
       end
+
+      it 'apply_on should properly handle product id scopes' do
+        subject.name = 'with_ids'
+        subject.arguments = ["#{product_1.id},#{product_2.id}"]
+        scope = Spree::Product.where(id: product_1.id)
+        subject.apply_on(scope).to_a.should eql([product_1])
+      end
     end
 
   end


### PR DESCRIPTION
Product IDs passed in the scope were being overridden by the product group's product IDs during the merge. This change chains the scopes instead of merging them.
Fixes issue #11.

Sorry, this PR was supposed to have 1-3-stable as the base branch, not master. I can't work out how to change it.
