### PR TITLE
Respecting new Spree localization practices + resolving issue #28

### DIFF
--- a/app/models/spree/product_scope.rb
+++ b/app/models/spree/product_scope.rb
@@ -28,12 +28,12 @@ module Spree
     # Applies product scope on Spree::Product model or another named scope
     def apply_on(another_scope)
       array = Array.wrap(self.arguments)
-      unless another_scope.class == ActiveRecord::Relation
+      unless another_scope.is_a?(ActiveRecord::Relation)
         another_scope = another_scope.send(:relation)
       end
       if Product.respond_to?(self.name.intern)
         if (array.blank? || array.size < 2)
-          if Product.method(self.name.intern).arity == 0
+          if Product.method(self.name.intern).arity == 0 || self.is_ordering?
             another_scope.send(self.name.intern)
           else
             # Since IDs are comma seperated in the first argument we need to correctly pass the ID array to the with_ids scope.

--- a/app/views/spree/admin/product_groups/_preview.html.erb
+++ b/app/views/spree/admin/product_groups/_preview.html.erb
@@ -3,7 +3,7 @@
 <h2><%= Spree::ProductGroup.human_attribute_name(:products) %> (<%= count %>)</h2>
 
 <% if count == 0 %>
-  <p data-hook="preview_empty"><%= t(:no_match_found) %></p>
+  <p data-hook="preview_empty"><%= Spree.t(:no_match_found) %></p>
 <% else %>
 
   <% if count > Spree::Config[:admin_pgroup_per_page] %>
@@ -14,7 +14,7 @@
     <thead>
       <tr data-hook="preview_header">
         <th><%= Spree::Product.human_attribute_name(:name) %></th>
-        <th><%= t(:action) %></th>
+        <th><%= Spree.t(:action) %></th>
       </tr>
     </thead>
     <tbody>
@@ -24,7 +24,7 @@
           <%= link_to product.name, product_url(product) %>
         </td>
         <td>
-          <%= link_to t(:edit), edit_admin_product_path(product) %>
+          <%= link_to Spree.t(:edit), edit_admin_product_path(product) %>
         </td>
       </tr>
     <% end %>

--- a/app/views/spree/admin/product_groups/_product_scope.html.erb
+++ b/app/views/spree/admin/product_groups/_product_scope.html.erb
@@ -19,6 +19,6 @@
     <% end %>
   </td>
   <td class="actions" data-hook="actions">
-    <%= link_to_delete product_scope, url: admin_product_group_product_scope_path(@product_group, product_scope), :no_text => true  %>
+    <%= link_to_with_icon 'cross icon-trash no-text', '', admin_product_group_product_scope_path(@product_group, product_scope), :remote => true, :method => 'delete' %>
   </td>
 </tr>

--- a/app/views/spree/admin/product_groups/edit.html.erb
+++ b/app/views/spree/admin/product_groups/edit.html.erb
@@ -7,7 +7,7 @@
 <% content_for :page_actions do %>
   <li>
     <%= button_link_to Spree.t(:back_to_product_groups_list), admin_product_groups_url, :icon => 'icon-arrow-left' %>
-  </li>  
+  </li>
 <% end %>
 
 <fieldset id="product_group_forms_container" data-hook>
@@ -15,19 +15,19 @@
   <%= form_for [:admin, @product_group], :html => { :id => 'product-group-form', :method => :put } do |f| %>
 
       <%= f.field_container :name do %>
-        <%= f.label :name, t(:name) %><br />
+        <%= f.label :name, Spree::ProductGroup.human_attribute_name(:name) %><br />
         <%= f.text_field :name %>
         <%= f.error_message_on :name %>
       <% end %>
 
       <%= f.field_container :permalink do %>
-        <%= f.label :permalink, t(:permalink) %><br />
+        <%= f.label :permalink, Spree::ProductGroup.human_attribute_name(:permalink) %><br />
         <%= f.text_field :permalink %>
         <%= f.error_message_on :permalink %>
       <% end %>
 
       <%= f.field_container :order_scope do %>
-        <%= f.label :order_scope, t(:sort_ordering) %><br />
+        <%= f.label :order_scope, Spree::ProductGroup.human_attribute_name(:sort_ordering) %><br />
         <%= f.select(:order_scope, Spree::Product.simple_scopes.collect{|p| [ t(:name, :scope =>[:product_scopes, :scopes, p]), p.to_s ] }) %>
       <% end %>
 
@@ -35,7 +35,7 @@
         <%= render :partial => 'product_scope', :collection => @product_group.product_scopes.reject {|s| s.is_ordering? } %>
       </table>
 
-    <%= button t(:update) %>
+    <%= button Spree.t(:update) %>
 
   <% end %>
 
@@ -54,7 +54,7 @@
     )
     %>
     <p>
-      <%= label_tag :product_scope_name, t(:add_scope) %>
+      <%= label_tag :product_scope_name, Spree.t(:add_scope) %>
       <%= select_tag 'product_scope[name]', options %>
       <%= submit_tag Spree.t(:add) %>
     </p>

--- a/app/views/spree/admin/product_groups/index.html.erb
+++ b/app/views/spree/admin/product_groups/index.html.erb
@@ -6,7 +6,7 @@
 
 <% content_for :page_actions do %>
   <li>
-    <%= button_link_to t(:new_product_group), new_object_url, :icon => 'icon-plus', :id => 'admin_new_product_group_link' %>
+    <%= button_link_to Spree.t(:new_product_group), new_object_url, :icon => 'icon-plus', :id => 'admin_new_product_group_link' %>
   </li>
 <% end %>
 
@@ -25,7 +25,7 @@
         <th><%= Spree::ProductGroup.human_attribute_name(:url) %></th>
         <th><%= Spree::ProductGroup.human_attribute_name(:product_scopes) %></th>
         <th><%= Spree::ProductGroup.human_attribute_name(:product_count) %></th>
-        <th><%= t(:action) %></th>
+        <th><%= Spree.t(:action) %></th>
       </tr>
     </thead>
     <tbody>

--- a/app/views/spree/admin/product_groups/new.html.erb
+++ b/app/views/spree/admin/product_groups/new.html.erb
@@ -7,17 +7,17 @@
 <% content_for :page_actions do %>
   <li>
     <%= button_link_to Spree.t(:back_to_product_groups_list), admin_product_groups_url, :icon => 'icon-arrow-left' %>
-  </li>  
+  </li>
 <% end %>
 
 <%= form_for [:admin, @product_group], :html => { :id => 'product-group-form', :multipart => true } do |f| %>
   <fieldset data-hook="name">
-    <legend><%= t(:product_group) %></legend>
+    <legend><%= Spree::ProductGroup.model_name.human %></legend>
     <%= f.field_container :name do %>
-      <%= f.label :name, t(:name) %>
+      <%= f.label :name, Spree::ProductGroup.human_attribute_name(:name) %>
       <%= f.text_field :name %>
       <%= f.error_message_on :name %>
     <% end %>
   </fieldset>
-  <%=  button t(:create) %>
+  <%=  button Spree.t(:create) %>
 <% end %>

--- a/app/views/spree/admin/product_groups/show.html.erb
+++ b/app/views/spree/admin/product_groups/show.html.erb
@@ -19,7 +19,7 @@
     <% @product_group.product_scopes.each do |product_scope| %>
       <tr <%= !product_scope.valid? ? "class='invalid'":'' %> data-hook="product_scopes_row">
         <td>
-          <%= product_scope.to_sentence %>
+          <%= product_scope.to_sentence.html_safe %>
         </td>
         <td>
           <%= product_scope.arguments.join(', ') %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,27 +1,32 @@
+---
 en:
   activerecord:
     models:
       spree/product_group:
-        one: Product Group
-        other: Product Groups
+        one: "Product group"
+        other: "Product groups"
+    attributes:
+      spree/product_group:
+        name: Name
+        product_count: "Product count"
+        product_scopes: "Product scopes"
+        products: "Products"
+        url: URL
+        permalink: "Permalink"
+        sort_ordering: "Sort ordering"
+      spree/product_scope:
+        arguments: "Arguments"
+        description: "Description"
   spree:
-    editing_product_group: Editing Product Group
-    showing_first_n: "Showing %{n}"
-    product_groups: Product Groups
-    new_product_group: New Product Group
-    back_to_product_groups_list: Back to Product Groups list
-  spree/product_group:
-    name: Name
-    product_count: "Product count"
-    product_scopes: "Product scopes"
-    products: "Products"
-    url: URL
-  spree/product_scope:
-    arguments: "Arguments"
-    description: "Description"
-  spree/product_group:
-    one: "Product group"
-    other: "Product groups"
+    add_scope: "Add Scope"
+    no_match_found: "No match found"
+    listing_product_groups: "Listing Product Groups"
+    editing_product_group: "Editing Product Group"
+    showing_first_n: "Showing first %{n}"
+    new_product_group: "New Product Group"
+    admin:
+      tab:
+        product_groups: "Product Groups"
   create_product_group_from_products: Create a new product group from these products
   product_scopes:
     groups:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -1,17 +1,32 @@
 ---
 ru:
-  spree/product_group:
-    name: Название
-    product_count: "Количество товаров"
-    product_scopes: "Фильтры товаров"
-    products: "Товары"
-    url: URL
-  spree/product_scope:
-    arguments: "Аргументы"
-    description: "Описание"
-  spree/product_group:
-    one: "Группа товаров"
-    other: "Группы товаров"
+  activerecord:
+    models:
+      spree/product_group:
+        one: "Группа товаров"
+        other: "Группы товаров"
+    attributes:
+      spree/product_group:
+        name: Название
+        product_count: "Количество товаров"
+        product_scopes: "Фильтры товаров"
+        products: "Товары"
+        url: URL
+        permalink: "Ссылка"
+        sort_ordering: "Сортировка"
+      spree/product_scope:
+        arguments: "Аргументы"
+        description: "Описание"
+  spree:
+    add_scope: "Добавить Фильтр"
+    no_match_found: "Записей не найдено"
+    listing_product_groups: "Группы товаров"
+    editing_product_group: "Редактирование Группы товаров"
+    showing_first_n: "Первые %{n}"
+    new_product_group: "Новая группа товаров"
+    admin:
+      tab:
+        product_groups: "Группы товаров"
   create_product_group_from_products: Создайте новую группу товаров на основе этих товаров
   product_scopes:
     groups:


### PR DESCRIPTION
Resubmitting.

"Product.method(self.name.intern).arity == 0" will not work for "ascend_by_updated_at" and other sorts cause it returns -1. This is because such scopes (added as simple scopes) were added via "scope" method, not like other scopes that were defined via "define_method". So this request should fix #28.

I saw a lot of "t()" helper was used in partials. This request also updated all views with "Spree.t" helper using. It adds correct translations too.
