### PR TITLE
ActiveRecord::Relation#count returns Hash

### DIFF
--- a/app/models/spree/product_group.rb
+++ b/app/models/spree/product_group.rb
@@ -146,7 +146,7 @@ module Spree
 
     def include?(product)
       res = apply_on(Product.where(:id => product.id), false)
-      res.count > 0
+      res.length > 0
     end
 
     def scopes_to_hash

--- a/app/models/spree/product_group.rb
+++ b/app/models/spree/product_group.rb
@@ -146,7 +146,7 @@ module Spree
 
     def include?(product)
       res = apply_on(Product.where(:id => product.id), false)
-      res.length > 0
+      res.any?
     end
 
     def scopes_to_hash


### PR DESCRIPTION
When trying to use this extension I uncovered an error `undefined method '>' for {}:ActiveSupport::OrderedHash`, with `product_group.rb:151:in 'include?'` at the top of the stack.

Changing the line 149 to use `ActiveRecord::Relation#any?` solved it.

This PR did break any specs when tested locally.
